### PR TITLE
Add GHC 6.12-specific dependencies

### DIFF
--- a/hsini.cabal
+++ b/hsini.cabal
@@ -21,7 +21,17 @@ flag Test
 
 library
     hs-source-dirs  : src
-    build-depends   : base ==4.3.*, bytestring ==0.9.*, containers ==0.4.*, mtl ==2.0.*, parsec ==3.1.*
+    if impl(ghc == 6.12.*)
+      build-depends:
+        base == 4.2.*,
+        bytestring ==0.9.*,
+        containers == 0.3.*,
+        mtl ==2.0.*,
+        parsec ==3.1.*
+    else
+      build-depends   :
+        base ==4.3.*, bytestring ==0.9.*, containers ==0.4.*, mtl ==2.0.*, parsec ==3.1.*
+
     exposed-modules : Data.Ini Data.Ini.Types Data.Ini.Reader
     other-modules   : Data.Ini.Reader.Internals
 


### PR DESCRIPTION
The package builds without issue on GHC 6.12, but the original dependencies did not permit it.  This change just adds a specific clause for GHC 6.12.
