### PR TITLE
Add missing modules needed for tests to compile

### DIFF
--- a/hsini.cabal
+++ b/hsini.cabal
@@ -27,6 +27,7 @@ test-suite hsini-tests
     type: exitcode-stdio-1.0
     hs-source-dirs: tst, src
     main-is: Main.hs
+    other-modules: Ini, ReaderI
     default-language : Haskell2010
     build-depends:
         base,


### PR DESCRIPTION
I the previous state, compilation of tests was failing, e.g., 

http://hydra.cryp.to/build/42063/nixlog/5/raw

BTW., I checked now and tests run OK on 7.8.
