### PR TITLE
Relax the bounds for mtl (#13)

### DIFF
--- a/hsini.cabal
+++ b/hsini.cabal
@@ -19,7 +19,7 @@ library
     hs-source-dirs  : src
     default-language : Haskell2010
     build-depends   : base >=4.2 && <4.8, bytestring >=0.9 && <0.11,
-        containers >=0.3 && <0.6, mtl >=2.0 && <2.2, parsec ==3.1.*
+        containers >=0.3 && <0.6, mtl >=2.0 && <2.3, parsec ==3.1.*
     exposed-modules : Data.Ini Data.Ini.Types Data.Ini.Reader
     other-modules   : Data.Ini.Reader.Internals
 


### PR DESCRIPTION
All 34 tests passed (23.89s)

Tested with GHC 7.8.4RC and mtl-2.2.1.
