### PR TITLE
Update to GHC 7.10.1

### DIFF
--- a/src/Data/Ini/Reader/Internals.hs
+++ b/src/Data/Ini/Reader/Internals.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE FlexibleContexts #-}
 -- |
 -- Module    : Data.Ini.Reader.Internals
 -- Copyright : 2011-2014 Magnus Therning

--- a/tst/ReaderI.hs
+++ b/tst/ReaderI.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE FlexibleContexts #-}
 {-# OPTIONS_GHC -XTemplateHaskell #-}
 -- Copyright : 2011-2014 Magnus Therning
 -- License   : BSD3


### PR DESCRIPTION
With these changes the package builds and the tests pass:

~/r/hsini$ ghc --version
The Glorious Glasgow Haskell Compilation System, version 7.10.1
~/r/hsini$ cabal test
Preprocessing test suite 'hsini-tests' for hsini-0.3.999...
Running 1 test suites...
Test suite hsini-tests: RUNNING...
Test suite hsini-tests: PASS
Test suite logged to: dist/test/hsini-0.3.999-hsini-tests.log
1 of 1 test suites (1 of 1 test cases) passed.
