### PR TITLE
Fix build for GHC 9

### DIFF
--- a/tst/ReaderI.hs
+++ b/tst/ReaderI.hs
@@ -115,7 +115,7 @@ case_optContParserSpace = let
     in expected @=? actual
 
 case_optContParserTab = let
-        expected = Right $OptionContL "foo"
+        expected = Right $ OptionContL "foo"
         actual = p2E optContParser "optCont" "\tfoo\n"
     in expected @=? actual
 


### PR DESCRIPTION
Closes #24
`$` becomes more sensitive to trailing whitespace since GHC 9.0.